### PR TITLE
Ability to control socket timeout and keepalive options via settings file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,5 @@ Authors
 * ??? - https://github.com/artscoop
 * Rick van Hattem - http://wol.ph/
 * Benjamin Wohlwend - https://github.com/piquadrat
+* Trbs - https://github.com/trbs
+

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,27 @@ REDISBOARD_ITEMS_PER_PAGE
 
 REDISBOARD_ITEMS_PER_PAGE - default 100. Used for paginating the items from a list or a sorted set.
 
+REDISBOARD_SOCKET_TIMEOUT
+-------------------------
+
+REDISBOARD_SOCKET_TIMEOUT - default None. Socket operations time out after this many seconds.
+
+REDISBOARD_SOCKET_CONNECT_TIMEOUT
+---------------------------------
+
+REDISBOARD_SOCKET_CONNECT_TIMEOUT - default None. Socket connect operation times out after this many seconds.
+
+REDISBOARD_SOCKET_KEEPALIVE
+---------------------------
+
+REDISBOARD_SOCKET_KEEPALIVE - default None. Enables or Disables socket keepalive.
+
+REDISBOARD_SOCKET_KEEPALIVE_OPTIONS
+-----------------------------------
+
+REDISBOARD_SOCKET_KEEPALIVE_OPTIONS - default None. Additional options for socket keepalive.
+
+
 Screenshots
 ===========
 

--- a/src/redisboard/models.py
+++ b/src/redisboard/models.py
@@ -29,6 +29,11 @@ REDISBOARD_DETAIL_SECONDS_KEYS = getattr(settings, 'REDISBOARD_DETAIL_SECONDS_KE
 
 REDISBOARD_SLOWLOG_LEN = getattr(settings, 'REDISBOARD_SLOWLOG_LEN', 10)
 
+REDISBOARD_SOCKET_TIMEOUT = getattr(settings, 'REDISBOARD_SOCKET_TIMEOUT', None)
+REDISBOARD_SOCKET_CONNECT_TIMEOUT = getattr(settings, 'REDISBOARD_SOCKET_CONNECT_TIMEOUT', None)
+REDISBOARD_SOCKET_KEEPALIVE = getattr(settings, 'REDISBOARD_SOCKET_KEEPALIVE', None)
+REDISBOARD_SOCKET_KEEPALIVE_OPTIONS = getattr(settings, 'REDISBOARD_SOCKET_KEEPALIVE_OPTIONS', None)
+
 
 def prettify(key, value):
     if key in REDISBOARD_DETAIL_SECONDS_KEYS:
@@ -95,6 +100,10 @@ class RedisServer(models.Model):
             port=self.port,
             password=self.password,
             unix_socket_path=unix_socket_path,
+            socket_timeout=REDISBOARD_SOCKET_TIMEOUT,
+            socket_connect_timeout=REDISBOARD_SOCKET_CONNECT_TIMEOUT,
+            socket_keepalive=REDISBOARD_SOCKET_KEEPALIVE,
+            socket_keepalive_options=REDISBOARD_SOCKET_KEEPALIVE_OPTIONS,
         )
 
     @connection.deleter

--- a/src/redisboard/views.py
+++ b/src/redisboard/views.py
@@ -1,5 +1,4 @@
 from logging import getLogger
-logger = getLogger(__name__)
 
 from django.core.paginator import Paginator
 from django.shortcuts import render
@@ -11,6 +10,8 @@ from django.http import HttpResponseNotFound
 from redis.exceptions import ResponseError
 
 from .utils import LazySlicingIterable
+
+logger = getLogger(__name__)
 
 REDISBOARD_ITEMS_PER_PAGE = getattr(settings, 'REDISBOARD_ITEMS_PER_PAGE', 100)
 


### PR DESCRIPTION
Allow to control ```socket_timeout```, ```socket_connect_timeout```, ```socket_keepalive```, ```socket_keepalive_options``` options via Django's settings file.

Made all the default ```None``` to be completely backwards compatible. Although I would suggest to that set at least ```REDISBOARD_SOCKET_CONNECT_TIMEOUT``` to some sensible value like ```15``` seconds and maybe set some default for ```REDISBOARD_SOCKET_TIMEOUT``` as well. This would lead to a better user experience, specially when combined with handling the timeout exception in the views, then having cases where the connection will wait for ever and basically kill the ```Django``` process.


