### PR TITLE
Fix typo in inspect.html template copy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog
 ============
 
+3.0.3 (2017-11-14)
+* Fixed typo in inspect.html template to reflect `out`.
+
 3.0.2 (2017-01-19)
 ------------------
 

--- a/src/redisboard/templates/redisboard/inspect.html
+++ b/src/redisboard/templates/redisboard/inspect.html
@@ -70,9 +70,9 @@
                 {% if db_detail.sampling %}
                     {% with db_detail.size as total %}
                         {% blocktrans count original.sampling_threshold as size %}
-                            {{ size }} random key our of {{ total }}
+                            {{ size }} random key out of {{ total }}
                         {% plural %}
-                            {{ size }} random keys our of {{ total }}
+                            {{ size }} random keys out of {{ total }}
                         {% endblocktrans %}
                     {% endwith %}
                 {% else %}


### PR DESCRIPTION
The goal of this PR is to fix two typos of: `our` where `out` is implied.