### PR TITLE
Added port as list_filter

### DIFF
--- a/src/redisboard/admin.py
+++ b/src/redisboard/admin.py
@@ -36,7 +36,7 @@ class RedisServerAdmin(admin.ModelAdmin):
         'tools',
     )
 
-    list_filter = 'label', 'hostname'
+    list_filter = 'label', 'hostname', 'port'
     ordering = ('hostname', 'port')
 
     def slowlog(self, obj):


### PR DESCRIPTION
Since Redis is effectively a single core program I run multiple Redis servers on the same machine on different ports. So having a filter for port would be a very useful addition in those cases :)